### PR TITLE
DSO-630-blackduck-unit-ruby-sdk-fix-full-scan

### DIFF
--- a/.github/workflows/CI-appsec-blackduck-master.yml
+++ b/.github/workflows/CI-appsec-blackduck-master.yml
@@ -11,6 +11,13 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6.8
+      - name: Install Dependencies
+        run: |
+          bundle install
 
       - name: Black Duck Intelligent Scan
         uses: synopsys-sig/synopsys-action@v1.2.0

--- a/.github/workflows/CI-appsec-blackduck-pr.yml
+++ b/.github/workflows/CI-appsec-blackduck-pr.yml
@@ -10,6 +10,13 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6.8
+      - name: Install Dependencies
+        run: |
+          bundle install
 
       - name: On pull requests - Black Duck RAPID Scan
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
As our initial scan failed with FAILURE_ACCURACY_NOT_MET error
We have to fix the build failure, so that native RUBY inspector can be applied by black duck detect. 
Native Inspector's accuracy is designated as HIGH, so Detect default accuracy requirements would be met and scan would succeed.

If this will not fix the issue, we will revert and use build less detector results that are sufficient for our purposes, we will run the scan with --detect.accuracy.required=NONE to suppress the accuracy error.