### PR TITLE
DSO-630-blackduck-unit-ruby-sdk-accuracy-NONE

### DIFF
--- a/.github/workflows/CI-appsec-blackduck-master.yml
+++ b/.github/workflows/CI-appsec-blackduck-master.yml
@@ -17,6 +17,7 @@ jobs:
         ### Use below configurations to set specific detect environment varibales
         env:
           DETECT_PROJECT_NAME: ${{ github.event.repository.name }}
+          DETECT_ACCURACY_REQUIRED: NONE
         with:
           blackduck_url: ${{ secrets.BLACKDUCK_URL }}
           blackduck_apiToken: ${{ secrets.BLACKDUCK_API_TOKEN }}

--- a/.github/workflows/CI-appsec-blackduck-pr.yml
+++ b/.github/workflows/CI-appsec-blackduck-pr.yml
@@ -17,6 +17,7 @@ jobs:
           ### Use below configurations to set specific detect environment varibales
         env:
           DETECT_PROJECT_NAME: ${{ github.event.repository.name }}
+          DETECT_ACCURACY_REQUIRED: NONE
         with:
           blackduck_url: ${{ secrets.BLACKDUCK_URL }}
           blackduck_apiToken: ${{ secrets.BLACKDUCK_API_TOKEN }}


### PR DESCRIPTION
According to blackduck support:


Each Detector has a few accuracy levels, for some Detectors High is implicitely expected.
What you can do is to pass --detect.accuracy.required=NONE for Detect not to fail on accuracy expectations.